### PR TITLE
Showcase variables option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,16 @@ Then add the validation rule to the GraphQL server ([apollo-server], [express-gr
 
 **Setup with express-graphql**
 ```javascript
-app.use('/graphql', graphqlHTTP({
+app.use('/graphql', graphqlHTTP((req, res, graphQLParams) => ({
   schema: MyGraphQLSchema,
   graphiql: true,
-  validationRules: [ costAnalyzer ]
-}));
+  validationRules: [ 
+     costAnalysis({
+       variables: graphQLParams.variables,
+       maximumCost: 1000,
+     })
+   ]
+})));
 ```
 
 **Setup with apollo-server-express**
@@ -55,7 +60,12 @@ app.use('/graphql', graphqlExpress(req => {
   return {
     schema,
     rootValue: null,
-    validationRules: [ costAnalyzer ],
+    validationRules: [ 
+      costAnalysis({
+        variables: req.body.variables,
+        maximumCost: 1000,
+      })
+    ]
   }
 }))
 ```


### PR DESCRIPTION
Passing the `variables` option was non-obvious to me and could have a bit of impact on the cost calculations, so I think it's worth highlighting as the default setup.

> Note: We use `apollo-server-express` so I'm not sure whether the syntax for `express-graphql` is correct, but according to their docs it _should_ work.