### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ cache:
   directories:
     - ./node_modules/
 
+before_install:
+  - if [[ $TRAVIS_NODE_VERSION == "6" ]]; then npm i -g npm@latest; fi
+
 install:
   - npm ci --production=false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,10 @@ env:
 language: node_js
 
 node_js:
+  - '6'
   - '8'
+  - '10'
+  - 'node'
 
 # https://docs.travis-ci.com/user/caching
 cache:


### PR DESCRIPTION
We should test on all currently supported LTS and stable releases to ensure that we catch breaking builds early.