### PR TITLE
Apply multipliers to fragments and inline fragments

### DIFF
--- a/src/costAnalysis.js
+++ b/src/costAnalysis.js
@@ -409,7 +409,7 @@ export default class CostAnalysis {
                 .getSchema()
                 .getType(fragment.typeCondition.name.value)
             nodeCost = fragment
-              ? this.computeNodeCost(fragment, fragmentType)
+              ? this.computeNodeCost(fragment, fragmentType, this.operationMultipliers)
               : this.defaultCost
             break
           }
@@ -422,7 +422,7 @@ export default class CostAnalysis {
                 .getType(childNode.typeCondition.name.value)
             }
             nodeCost = childNode
-              ? this.computeNodeCost(childNode, inlineFragmentType)
+              ? this.computeNodeCost(childNode, inlineFragmentType, this.operationMultipliers)
               : this.defaultCost
             break
           }


### PR DESCRIPTION
This PR fixes multipliers not being propagated to fragments and inline fragments.

Before, the calculated cost of:
```gql
query {
  first(limit: 10) {
    second(limit: 10) {
      string
    }
  }
}
```
was higher than the cost of:

```gql
query {
  first(limit: 10) {
    ...firstFields
  }
}
      
fragment firstFields on First {
  second(limit: 10) {
    string
  }
}
```
even though they're basically the same queries.