### PR TITLE
Suppress extraneous error when ValuesOfCorrectType validation fails

### DIFF
--- a/src/costAnalysis.js
+++ b/src/costAnalysis.js
@@ -208,6 +208,10 @@ export default class CostAnalysis {
       multipliers = this.getMultipliersFromString(multipliers, fieldArgs)
     }
 
+    if (typeof complexity === 'function') {
+      complexity = complexity.apply(this, [{ node, parentType, fieldArgs }, costObject])
+    }
+
     return {
       useMultipliers,
       multiplier,

--- a/src/costAnalysis.js
+++ b/src/costAnalysis.js
@@ -198,8 +198,15 @@ export default class CostAnalysis {
     }
 
     let { useMultipliers, multiplier, complexity, multipliers } = costObject
+
+    // NB multiplier is deprecated
     multiplier = multiplier && selectn(multiplier, fieldArgs)
-    multipliers = this.getMultipliersFromString(multipliers, fieldArgs)
+
+    if (typeof multipliers === 'function') {
+      multipliers = multipliers.apply(this, [{ node, parentType, fieldArgs }, costObject])
+    } else {
+      multipliers = this.getMultipliersFromString(multipliers, fieldArgs)
+    }
 
     return {
       useMultipliers,

--- a/src/costAnalysis.js
+++ b/src/costAnalysis.js
@@ -349,7 +349,8 @@ export default class CostAnalysis {
               this.options.variables || {}
             )
           } catch (e) {
-            this.context.reportError(e)
+            // ValuesOfCorrectType validation will report this
+            break
           }
 
           // it the costMap option is set, compute the cost with the costMap provided

--- a/src/costAnalysis.test.js
+++ b/src/costAnalysis.test.js
@@ -418,6 +418,45 @@ describe('Cost analysis Tests', () => {
     expect(visitor.cost).toEqual(expectedCost)
   })
 
+  test('if multipliers is provided as a function in costMap, we compute the score with it', () => {
+    const limit = 20
+    const ast = parse(`
+      query {
+        first(limit: ${limit}) {
+          second(limit: ${limit})
+        }
+      }
+    `)
+
+    const costMap = {
+      Query: {
+        first: {
+          useMultipliers: true,
+          complexity: 2,
+          multipliers: ['limit']
+        }
+      },
+      First: {
+        second: {
+          useMultipliers: true,
+          complexity: 9,
+          multipliers: ({ fieldArgs }) => [fieldArgs.limit * 3, fieldArgs.limit + 1]
+        }
+      }
+    }
+
+    const context = new ValidationContext(schema, ast, typeInfo)
+    const visitor = new CostAnalysis(context, {
+      maximumCost: 100,
+      costMap
+    })
+    visit(ast, visitWithTypeInfo(typeInfo, visitor))
+    const firstCost = limit * costMap.Query.first.complexity
+    const secondCost = limit * ((limit * 3) + (limit + 1)) * costMap.First.second.complexity
+    const expectedCost = firstCost + secondCost
+    expect(visitor.cost).toEqual(expectedCost)
+  })
+
   test('if costMap node is undefined, return the defaultCost', () => {
     const ast = parse(`
       query {


### PR DESCRIPTION
Because all validation rules are run, and all can report errors, and not just the first one that fails, and because `costAnalysis` depends on input arguments which may fail `ValuesOfCorrectType` validation, an extraneous error was being reported by `costAnalysis`, when it calls `getArgumentValues`, which may make it look like this is the part of the code with the problem, as this error may appear first in the `errors` property array of the query response, and that's all users may look at. (See https://github.com/pa-bru/graphql-cost-analysis/issues/29 for an example of where this may have happened).

The error when calling `getArgumentValues` is a side-effect of failed validation elsewhere, and should not be reported from this validator.

This patch simply breaks out of the cost calculation for the contextual node when this occurs, which may, or may not subsequently report an over-cost error from the rest of the graph, but query execution will fail for the other validation reason anyway.